### PR TITLE
Fix Errors on Node 0.10.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["transform-runtime"],
   "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.2.31",
-    "aws-sdk-config-loader": "^1.0.0",
+    "aws-sdk-config-loader": "^1.0.1",
+    "babel-runtime": "^6.6.1",
     "chalk": "^1.1.1",
     "cli-table": "^0.3.1",
     "commander": "^2.8.1",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "babel-cli": "^6.1.4",
     "babel-eslint": "6.0.0-beta.6",
+    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "^6.1.4",
     "esdoc": "^0.4.3",
     "eslint": "^2.4.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ import minimatch from 'minimatch';
  * @return {string}
  */
 export function getTagValue(tags, key) {
-  const tag = tags.find(t => t.Key === key);
+  const tag = Array.find(tags, t => t.Key === key);
   return tag && tag.Value;
 }
 


### PR DESCRIPTION
- Raises `ReferenceError: Promise is not defined`
  - Codes tranformed babel includes `Promise`, but Node 0.10.x does not have it...
- Raise `TypeError: Object [object Object],[object Object] has no method 'find'`